### PR TITLE
Make token and jwt expire 24 hours after issue

### DIFF
--- a/src/actions/setStreamToken.ts
+++ b/src/actions/setStreamToken.ts
@@ -4,7 +4,7 @@ import { v4 as uuid } from 'uuid'
 import { STREAM_TOKEN_COOKIE_NAME } from '../constants'
 import { sign } from '../lib/jwt'
 
-const ONE_DAY_MS = 1000 * 60 * 60 * 24 * 30
+const ONE_DAY_MS = 1000 * 60 * 60 * 24
 
 export async function setStreamToken(
   request: NextRequest,
@@ -14,15 +14,16 @@ export async function setStreamToken(
     return
   }
 
+  const expiration = new Date(Date.now() + ONE_DAY_MS)
   const token = await sign(
     {
       viewerId: uuid(),
     },
-    { exp: '1d' },
+    { exp: Math.floor(expiration.getTime() / 1000) },
   )
 
   response.cookies.set({
-    expires: new Date(Date.now() + ONE_DAY_MS),
+    expires: expiration,
     httpOnly: true,
     name: STREAM_TOKEN_COOKIE_NAME,
     path: '/',

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -5,7 +5,7 @@ import { SIGNING_SECRET } from '../constants'
 
 export type SignOptions = {
   alg?: string
-  exp?: string
+  exp?: string | number
 }
 
 const secret = new TextEncoder().encode(SIGNING_SECRET)


### PR DESCRIPTION
### Description

Make JWT exp and `STREAM_TOKEN` cookie expire 24 hrs after issue